### PR TITLE
chore(deps): bump python to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 RUN apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numpy==1.24.4
 opencv_python==4.9.0.80
 paho_mqtt==2.0.0
 PyYAML==6.0.1
-tflite_support==0.4.3
+tflite_support==0.4.4
 requests==2.31.0
 Pillow==10.2.0


### PR DESCRIPTION
This PR moves to Python 3.11. It also bumps tflite-support to 0.4.4 as 0.4.3 doesn't have Python 3.11 support