### PR TITLE
fix: revert to python3.9 to use tflite-support 0.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.9
 RUN apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Flask==3.0.2
 numpy==1.26.4
 opencv_python==4.9.0.80
-paho_mqtt==2.0.0
+paho_mqtt==1.6.1
 PyYAML==6.0.1
-tflite_support==0.4.4
+tflite_support==0.4.3
 requests==2.31.0
 Pillow==10.2.0

--- a/speciesid.py
+++ b/speciesid.py
@@ -108,7 +108,7 @@ def on_message(client, userdata, message):
                 "crop": 1,
                 "quality": 95
             }
-            response = requests.get(snapshot_url, params=params)
+            response = requests.get(snapshot_url, params=params, timeout=60)
             # Check if the request was successful (HTTP status code 200)
             if response.status_code == 200:
                 # Open the image from the response content and convert it to a NumPy array
@@ -226,7 +226,7 @@ def run_mqtt_client():
     print("Starting MQTT client. Connecting to: " + config['frigate']['mqtt_server'], flush=True)
     now = datetime.now()
     current_time = now.strftime("%Y%m%d%H%M%S")
-    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, "birdspeciesid" + current_time)
+    client = mqtt.Client("birdspeciesid" + current_time)
     client.on_message = on_message
     client.on_disconnect = on_disconnect
     client.on_connect = on_connect


### PR DESCRIPTION
This PR revert tflite-support to 0.4.3 and paho-mqtt to v1 to get things working. Classification didn't work with v0.4.3 of tflite-support. I will look into it and bump these dependencies back up once I find a fix